### PR TITLE
Replace removed Redis task includes with include_tasks

### DIFF
--- a/part11-redis-install/redis-install/tasks/main.yml
+++ b/part11-redis-install/redis-install/tasks/main.yml
@@ -1,3 +1,3 @@
-- include: apt_update.yml
-- include: install.yml
-- include: configure.yml
+- ansible.builtin.include_tasks: apt_update.yml
+- ansible.builtin.include_tasks: install.yml
+- ansible.builtin.include_tasks: configure.yml


### PR DESCRIPTION
This updates the Redis role task entrypoint to use `ansible.builtin.include_tasks`
instead of the removed bare `include` action.

With recent ansible-core versions, the current task file fails before the role can
run:

```text
ERROR! [DEPRECATED]: ansible.builtin.include has been removed.
Use include_tasks or import_tasks instead.
```

The affected file currently includes three fixed task files:

- `apt_update.yml`
- `install.yml`
- `configure.yml`

Using `ansible.builtin.include_tasks` keeps the same structure while making the
role compatible with ansible-core 2.16+.

Validation I used:

```bash
ansible-playbook --syntax-check part11-redis-install/ansible-learning.yml
```

Before this change, ansible-core 2.17 fails on `redis-install/tasks/main.yml:1`.
An older ansible-core 2.15 run only reports a deprecation warning.
