### PR TITLE
Install Grafana GPG prerequisites and remove redundant sudo

### DIFF
--- a/part09-grafana-install/ansible-learning.yml
+++ b/part09-grafana-install/ansible-learning.yml
@@ -5,7 +5,10 @@
   tasks:
     - name: Install nessesary package
       apt: 
-        name: apt-transport-https
+        name:
+          - apt-transport-https
+          - curl
+          - gnupg
         state: present
         update_cache: yes
 

--- a/part09-grafana-install/ansible-learning.yml
+++ b/part09-grafana-install/ansible-learning.yml
@@ -10,7 +10,7 @@
         update_cache: yes
 
     - name: add grafana gpg key
-      shell: curl https://packages.grafana.com/gpg.key | sudo apt-key add -
+      shell: curl https://packages.grafana.com/gpg.key | apt-key add -
 
     - name: add grafana repo 
       apt_repository:


### PR DESCRIPTION
This updates the Grafana install playbook's repository-key setup for clean Ubuntu hosts.

The playbook already runs with `become: true`, but the GPG-key task still piped through `sudo`. Minimal Ubuntu images may not have `sudo` installed, so the task can fail before the Grafana repository is added.

The key task also depends on `curl` and GPG tooling being present. This PR now installs those prerequisites before adding the Grafana key:

```yaml
name:
  - apt-transport-https
  - curl
  - gnupg
```

and keeps the key command running under Ansible's existing privilege escalation:

```yaml
shell: curl https://packages.grafana.com/gpg.key | apt-key add -
```

Validation:

- Checked the diff with `git diff --check`.
- Re-ran the playbook path in a clean Ubuntu 22.04 container with ansible-core 2.16.
- The updated playbook progressed through GPG key import, repository setup, and Grafana package installation.

Note: in that minimal container, the final service-start task still depends on the target service/init environment. This PR is limited to fixing the repository-key setup prerequisites.
